### PR TITLE
cd before folder in command after git clone

### DIFF
--- a/2.0/sphinx/admin/guide/install/source.txt
+++ b/2.0/sphinx/admin/guide/install/source.txt
@@ -16,7 +16,7 @@ Installation steps
 
 ::
 
-    $ git clone https://github.com/zatosource/zato && zato/code
+    $ git clone https://github.com/zatosource/zato && cd zato/code
     Cloning into 'zato'...
     [snip]
     code$


### PR DESCRIPTION
`cd` is missing before the folders in the `clone` command