### PR TITLE
Fix Github links

### DIFF
--- a/2.0/sphinx/admin/guide/install-config/config-server.txt
+++ b/2.0/sphinx/admin/guide/install-config/config-server.txt
@@ -505,7 +505,7 @@ If a service uses a target name, the request will be executed on a server only i
 the target, that is, if the target provided by the service matches one of the patterns configured for server.
 
 For :ref:`invoke <progguide-write-service-invoke>` - a service will receive a
-`ZatoException <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+`ZatoException <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
 if the target is not supported. For :ref:`invoke_async <progguide-write-service-invoke_async>`, the request
 will be dropped. Unless on DEBUG level or more verbose the request will be dropped silently.
 
@@ -536,7 +536,7 @@ spring.context_class
 ~~~~~~~~~~~~~~~~~~~~
 
 Name of a Python class to create the 
-`Spring Python context <https://github.com/zatosource/zato/blob/master/code/zato-server/src/zato/server/spring_context.py>`_
+`Spring Python context <https://github.com/zatosource/zato/blob/main/code/zato-server/src/zato/server/spring_context.py>`_
 from.
 
 misc.internal_services_may_be_deleted

--- a/2.0/sphinx/progguide/clients/python.txt
+++ b/2.0/sphinx/progguide/clients/python.txt
@@ -17,7 +17,7 @@ both use :ref:`AnyServiceInvoker <progguide-clients-python-AnyServiceInvoker>`.
 
 Depending on how exactly you'd like to invoke a Zato service you will want to pick
 a particular client class, each documented later in the chapter. The classes are defined
-in the `zato.client <https://github.com/zatosource/zato/blob/master/code/zato-client/src/zato/client/__init__.py>`_
+in the `zato.client <https://github.com/zatosource/zato/blob/main/code/zato-client/src/zato/client/__init__.py>`_
 module.
 
 :ref:`AnyServiceInvoker <progguide-clients-python-AnyServiceInvoker>` is the only
@@ -64,7 +64,7 @@ Each client class accepts the same set of arguments when creating an instance.
                             printed out on screen for instance, how many characters
                             of the response actually to output. Defaults 
                             to 
-                            `zato.client.DEFAULT_MAX_RESPONSE_REPR <https://github.com/zatosource/zato/blob/master/code/zato-client/src/zato/client/__init__.py>`_ which is 2500 characters.
+                            `zato.client.DEFAULT_MAX_RESPONSE_REPR <https://github.com/zatosource/zato/blob/main/code/zato-client/src/zato/client/__init__.py>`_ which is 2500 characters.
   :type max_response_repr: int
    
   :param max_cid_repr: Used in the same circumstances as max_response_repr. A CID
@@ -73,7 +73,7 @@ Each client class accepts the same set of arguments when creating an instance.
                         printed on either end of a CID. For instance, if CID is
                         K149081821097240318192876103867382447697 and max_cid_repr is 5,
                         __repr__ will use 'K1490..47697' with any characters in between
-                        suppressed. max_cid_repr defaults to 5 and you can use the `zato.client.CID_NO_CLIP <https://github.com/zatosource/zato/blob/master/code/zato-client/src/zato/client/__init__.py>`_ constant to turn the clipping
+                        suppressed. max_cid_repr defaults to 5 and you can use the `zato.client.CID_NO_CLIP <https://github.com/zatosource/zato/blob/main/code/zato-client/src/zato/client/__init__.py>`_ constant to turn the clipping
                         feature off.
   :type max_cid_repr: int                        
 
@@ -113,13 +113,13 @@ invoke
   :type headers:  dict
   
   :param channel: :ref:`Channel <progguide-write-service-channel>` the service will be invoked with
-  :type channel:  `zato.common.CHANNEL <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+  :type channel:  `zato.common.CHANNEL <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
   
   :param data_format: :ref:`Data format <progguide-write-service-data_format>` the service will be invoked with
-  :type data_format:  `zato.common.DATA_FORMAT <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+  :type data_format:  `zato.common.DATA_FORMAT <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
   
   :param transport: Transport the service will be invoked over
-  :type transport:  `zato.common.TRANSPORT <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+  :type transport:  `zato.common.TRANSPORT <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
   
   :param id:    ID of the service to invoke. Either name or id must be provided.
   :type id:     int
@@ -128,7 +128,7 @@ invoke
   :type to_json:  bool
   
   :param output_repeated: Whether the expected output is repeated. If left at 
-                          `zato.common.ZATO_NON_GIVEN <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_,
+                          `zato.common.ZATO_NON_GIVEN <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_,
                           it will be assumed to be true if the service name ends in 'list',
                           so that 'my.application.customer.get-list' will by default be assumed to return
                           a :doc:`SIO <../sio>` list of objects
@@ -522,7 +522,7 @@ Response object
 
 The result of invoking a service, no matter if in a blocking way or asynchronously,
 is always a 
-`Response <https://github.com/zatosource/zato/blob/master/code/zato-client/src/zato/client/__init__.py>`_
+`Response <https://github.com/zatosource/zato/blob/main/code/zato-client/src/zato/client/__init__.py>`_
 object which provides access to the underlying data a service
 produced along with a couple of useful attributes. 
 

--- a/2.0/sphinx/progguide/helpers.txt
+++ b/2.0/sphinx/progguide/helpers.txt
@@ -4,7 +4,7 @@
 Helper services
 ===============
 
-`zato.server.service.internal.helpers <https://github.com/zatosource/zato/blob/master/code/zato-server/src/zato/server/service/internal/helpers.py>`_
+`zato.server.service.internal.helpers <https://github.com/zatosource/zato/blob/main/code/zato-server/src/zato/server/service/internal/helpers.py>`_
 contains a set of helper services coming in handy during development and documented below.
 
 The services can be used either standalone or as base classes for user-defined ones.

--- a/2.0/sphinx/progguide/html.txt
+++ b/2.0/sphinx/progguide/html.txt
@@ -9,7 +9,7 @@ HTML from services. For instance, a set of services performing background batch 
 to consult each week.
 
 To use `Django <https://www.djangoproject.com/>`_ templates in responses a service should subclass
-`zato.server.service.internal.helpers.HTMLService <https://github.com/zatosource/zato/blob/master/code/zato-server/src/zato/server/service/internal/helpers.py>`_
+`zato.server.service.internal.helpers.HTMLService <https://github.com/zatosource/zato/blob/main/code/zato-server/src/zato/server/service/internal/helpers.py>`_
 and assign HTML output as using *self.set_html_payload* providing the method with a dictionary of context and a template
 the context should be rendered in.
 

--- a/2.0/sphinx/progguide/outconn/imap.txt
+++ b/2.0/sphinx/progguide/outconn/imap.txt
@@ -29,7 +29,7 @@ self.email.imap.get
   :param name: Name of the IMAP connection to use
   :type name: string
 
-  :rtype: (A `zato.server.connection.email.IMAPConnection <https://github.com/zatosource/zato/blob/master/code/zato-server/src/zato/server/connection/email.py>`_ object)
+  :rtype: (A `zato.server.connection.email.IMAPConnection <https://github.com/zatosource/zato/blob/main/code/zato-server/src/zato/server/connection/email.py>`_ object)
 
 Usage example
 -------------

--- a/2.0/sphinx/progguide/outconn/smtp.txt
+++ b/2.0/sphinx/progguide/outconn/smtp.txt
@@ -23,7 +23,7 @@ self.email.smtp.get
 
   Fetches an object whose .conn attribute represents a connection to an SMTP server.
 
-  The object's .send method can be used to send emails using `zato.common.SMTPMessage <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py#L875>`_
+  The object's .send method can be used to send emails using `zato.common.SMTPMessage <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py#L875>`_
   objects.
 
   :param name: Name of the :doc:`SMTP connection <../../web-admin/email/smtp>` connection to use

--- a/2.0/sphinx/progguide/patterns/fan-out-fan-in.txt
+++ b/2.0/sphinx/progguide/patterns/fan-out-fan-in.txt
@@ -123,7 +123,7 @@ as a final and target callback. Each callback is invoked asynchronously, in isol
 
 Upon execution, each callback's :ref:`self.channel <progguide-write-service-channel>` attribute will be set to either
 *FANOUT_ON_FINAL* or *FANOUT_ON_TARGET* from 
-`zato.common.CHANNEL <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_.
+`zato.common.CHANNEL <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_.
 
 On input, a final callback's *self.request.payload* attribute will be a Python dictionary with the contents in the format as below:
 

--- a/2.0/sphinx/progguide/patterns/parallel-exec.txt
+++ b/2.0/sphinx/progguide/patterns/parallel-exec.txt
@@ -88,7 +88,7 @@ Each callback is invoked asynchronously, in isolation from any other callbacks d
 
 Upon execution, each callback's :ref:`self.channel <progguide-write-service-channel>` attribute will be set to 
 *PARALLEL_EXEC_ON_TARGET* from 
-`zato.common.CHANNEL <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_.
+`zato.common.CHANNEL <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_.
 
 On input, a callback's *self.request.payload* attribute will be a Python dictionary with the contents in the format as below:
 

--- a/2.0/sphinx/progguide/request-response.txt
+++ b/2.0/sphinx/progguide/request-response.txt
@@ -46,7 +46,7 @@ Request
 -------
 
 An instance of 
-`zato.server.service.Request <https://github.com/zatosource/zato/blob/master/code/zato-server/src/zato/server/service/__init__.py>`_
+`zato.server.service.Request <https://github.com/zatosource/zato/blob/main/code/zato-server/src/zato/server/service/__init__.py>`_
 class, each service's self.request provides access to several interesting
 attributes regarding the input data.
 
@@ -108,7 +108,7 @@ Response
 --------
 
 An instance of 
-`zato.server.service.Response <https://github.com/zatosource/zato/blob/master/code/zato-server/src/zato/server/service/__init__.py>`_
+`zato.server.service.Response <https://github.com/zatosource/zato/blob/main/code/zato-server/src/zato/server/service/__init__.py>`_
 class, self.response attribute of each service instance influences what the application
 invoking a service will receive.
 
@@ -122,7 +122,7 @@ payload          A service can assign output parameters directly to payload
                  the response.
                
 result           Defaults to ZATO_OK and must be either ZATO_OK or ZATO_ERROR from 
-                 `zato.common <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_.
+                 `zato.common <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_.
                  If the latter, an exception will be raised and signalled to the 
                  calling invocation in a transport-specific way, e.g. using
                  a Fault message for SOAP channels. A proper status_code will

--- a/2.0/sphinx/progguide/rest/json-adapter.txt
+++ b/2.0/sphinx/progguide/rest/json-adapter.txt
@@ -11,7 +11,7 @@ Adapter services are intended to use either as pass-through proxy ones or as par
 unless they are proxies, they won't be typically mounted on HTTP channels.
 
 After subclassing
-`zato.server.service.adapter.JSONAdapter <https://github.com/zatosource/zato/blob/master/code/zato-server/src/zato/server/service/adapter.py>`_
+`zato.server.service.adapter.JSONAdapter <https://github.com/zatosource/zato/blob/main/code/zato-server/src/zato/server/service/adapter.py>`_
 it's possible to configure the service in a declarative manner, without a need to implement the
 :ref:`handle <progguide-write-service-handle>` method.
 
@@ -52,8 +52,8 @@ apply_params    --       APPLY_AFTER_REQUEST                 Must be either
                                                              or
                                                              APPLY_BEFORE_REQEUST
                                                              from
-                                                             `zato.common.ADAPTER_PARAMS <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_.
+                                                             `zato.common.ADAPTER_PARAMS <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_.
                                                              If the former, self.params will take precedence over self.request.payload. The other way around if the latter.
 raise_error_on  --       ['4', '5']                          A list of prefixes of status codes returned from the endpoint which will make the adapter raise
-                                                             a `zato.common.HTTPException <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+                                                             a `zato.common.HTTPException <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
 =============== ======== =================================== =================================================================================================================================================

--- a/2.0/sphinx/progguide/service-dev.txt
+++ b/2.0/sphinx/progguide/service-dev.txt
@@ -5,7 +5,7 @@ Developing services
 ===================
 
 From a programmer's point of view, a service is a Python class that subclasses
-`zato.server.Service <https://github.com/zatosource/zato/blob/master/code/zato-server/src/zato/server/service/__init__.py>`_
+`zato.server.Service <https://github.com/zatosource/zato/blob/main/code/zato-server/src/zato/server/service/__init__.py>`_
 and implements a handle(self) method.
 
 Below is the simplest possible Zato service meant to illustrate the point of how
@@ -179,7 +179,7 @@ Can be one of:
 * 'zmq'
 
 The constants are defined in the 
-`zato.common.CHANNEL <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+`zato.common.CHANNEL <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
 class.
 
 ::
@@ -216,7 +216,7 @@ without prior notice.
 Note that when 
 :ref:`publishing <progguide-write-service-broker-client-publish>`
 a 
-`SERVICE.PUBLISH.value <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/broker_message.py>`_
+`SERVICE.PUBLISH.value <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/broker_message.py>`_
 message to more than one server, each server worker will receive a request
 with the same CID.
 
@@ -259,7 +259,7 @@ a particular data format. It can be one of:
 * 'xml'
 
 The constants are defined in the 
-`zato.common.DATA_FORMAT <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+`zato.common.DATA_FORMAT <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
 class.
 
 ::
@@ -400,7 +400,7 @@ it was. None if the scheduler wasn't used. Can be one of:
 * 'cron_style'
 
 The constants are defined in the 
-`zato.common.SCHEDULER_JOB_TYPE class <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_.
+`zato.common.SCHEDULER_JOB_TYPE class <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_.
 
 ::
 
@@ -450,7 +450,7 @@ logger
 ``````
 
 A logger, instance of
-`zato.server.log.ZatoLogger <https://github.com/zatosource/zato/blob/master/code/zato-server/src/zato/server/log.py>`_, 
+`zato.server.log.ZatoLogger <https://github.com/zatosource/zato/blob/main/code/zato-server/src/zato/server/log.py>`_, 
 used for writing messages out to server logs.
 This is a thin wrapper around `Python's logging.Logger <http://docs.python.org/2.7/library/logging.html>`_
 which lets one use a 'cid' argument in addition to what is ordinarily available
@@ -965,7 +965,7 @@ invoke
   discern that it's not being invoked through a regular channel created in the
   :doc:`web admin <../web-admin/intro>` or via :doc:`Zato's public API </public-api/intro>`.
   
-  A `ZatoException <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_ will be raised if a service attempts to invoke itself.
+  A `ZatoException <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_ will be raised if a service attempts to invoke itself.
   
   Visit :doc:`this chapter <./invoking-services>` for more information on how to invoke
   other services depending on the data format they expect.
@@ -974,7 +974,7 @@ invoke
                :ref:`invocation target <admin-guide-config-server-invoke_target_patterns_allowed>`, a label
                assigned to one or more selected servers in a cluster ensuring in that way that only
                these targets will receive the request. The syntax for using targets is *service_name@target_name*.
-               A `ZatoException <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+               A `ZatoException <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
                will be raised if the server the service is invoked on does not accept the provided target.
   :type name: string
   
@@ -983,14 +983,14 @@ invoke
                   :doc:`SIO<./sio>`.
   
   :param channel: :ref:`Channel type <progguide-write-service-channel>` a service will think it's invoked over
-  :type channel: `zato.common.CHANNEL <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+  :type channel: `zato.common.CHANNEL <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
   
   :param data_format: :ref:`Data format <progguide-write-service-data_format>` a service expects, if any.
                       Can be skipped if the service uses :doc:`SIO<./sio>` and payload is a dictionary.
-  :type data_format: `zato.common.DATA_FORMAT <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+  :type data_format: `zato.common.DATA_FORMAT <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
   
   :param transport: Transport a service will think it's invoked with
-  :type transport: `zato.common.TRANSPORT <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+  :type transport: `zato.common.TRANSPORT <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
   
   :param serialize: If the service which is invoked uses :doc:`SIO <./sio>`, 
                     whether its response should be serialized to data_format.

--- a/2.0/sphinx/project/changelog.txt
+++ b/2.0/sphinx/project/changelog.txt
@@ -146,7 +146,7 @@
 
 * :ref:`OpenID in web admin <admin-guide-config-web-admin-open-id>`
 
-* Constants in `zato.common.broker_message <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/broker_message.py>`_
+* Constants in `zato.common.broker_message <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/broker_message.py>`_
   became wrappers around integers - use *.value* attribute to reference them. For instance, SERVICE.PUBLISH.value instead of SERVICE.PUBLISH.
 
 * Added a :ref:`hot_deploy.delete_after_pick_up <admin-guide-config-server-hot_deploy.delete_after_pick_up>` flag,

--- a/2.0/sphinx/project/get-involved.txt
+++ b/2.0/sphinx/project/get-involved.txt
@@ -1,7 +1,7 @@
 License and getting involved
 ============================
 
-Want to contribute ideas or code? **Superb!** The project is under `LGPL <https://github.com/zatosource/zato/blob/master/LICENSE.txt>`_
+Want to contribute ideas or code? **Superb!** The project is under `LGPL <https://github.com/zatosource/zato/blob/main/LICENSE.txt>`_
 - a liberal license allowing for pretty much unlimited usage and modifications.
 
 * Programmers should familiarize themselves with 
@@ -15,7 +15,7 @@ Want to contribute ideas or code? **Superb!** The project is under `LGPL <https:
 
   * All other parts are in Python and make heavy use of other open-source projects,
     there are 
-    many dependencies listed in buildout.cfg <https://github.com/zatosource/zato/blob/master/code/buildout.cfg>`_
+    many dependencies listed in buildout.cfg <https://github.com/zatosource/zato/blob/main/code/buildout.cfg>`_
 
 * Want to send a quick documentation patch or suggestion? Just 
   `open a new ticket in GitHub <https://github.com/zatosource/zato/issues>`_

--- a/2.0/sphinx/stats/guide.txt
+++ b/2.0/sphinx/stats/guide.txt
@@ -26,7 +26,7 @@ broker:
 * :ref:`CID <progguide-write-service-cid>` the service has been invoked with
 
 Zato's own 
-`internal (look up stats_jobs) <https://github.com/zatosource/zato/blob/master/code/zato-server/src/zato/server/spring_context.py>`_
+`internal (look up stats_jobs) <https://github.com/zatosource/zato/blob/main/code/zato-server/src/zato/server/spring_context.py>`_
 :doc:`scheduler's jobs <../progguide/scheduler>` aggregate raw information
 into higher-order structures, all stored in Redis too - per minute stats are
 converted into per hour status, these get aggregated into per day information and so

--- a/2.0/sphinx/tutorial/01.txt
+++ b/2.0/sphinx/tutorial/01.txt
@@ -228,7 +228,7 @@ For instance:
 Note the highlighted line - these are credentials you'll need to log into a
 :doc:`web admin's instance <../web-admin/intro>`
 just created. In case you feel the
-`randomly generated password <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/markov_passwords.py>`_,
+`randomly generated password <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/markov_passwords.py>`_,
 even  a human-readable one, should still be changed, you can do it using the
 :doc:`zato update password <../../admin/cli/update-password>`
 command.

--- a/2.0/sphinx/web-admin/outgoing/ftp.txt
+++ b/2.0/sphinx/web-admin/outgoing/ftp.txt
@@ -30,7 +30,7 @@ Name                Connection name
 Active              Whether the connection can be used by services or not. If a connection
                     is not active a service will encounter 
                     a 
-                    `zato.common.Inactive <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+                    `zato.common.Inactive <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
                     exception when attempting to use it.
 Host                FTP server's host
 Port                Port to connect to

--- a/2.0/sphinx/web-admin/outgoing/plain-http.txt
+++ b/2.0/sphinx/web-admin/outgoing/plain-http.txt
@@ -29,7 +29,7 @@ Name                Connection name
 Active              Whether the connection can be used by services or not. 
 
                     If a connection is not active a service will encounter a 
-                    `zato.common.Inactive <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+                    `zato.common.Inactive <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
                     exception when attempting to use it.
                     
                     Note that an inactive connection still can be 

--- a/2.0/sphinx/web-admin/outgoing/soap.txt
+++ b/2.0/sphinx/web-admin/outgoing/soap.txt
@@ -27,7 +27,7 @@ Name                Connection name
 Active              Whether the connection can be used by services or not. 
 
                     If a connection is not active a service will encounter a 
-                    `zato.common.Inactive <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+                    `zato.common.Inactive <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
                     exception when attempting to use it.
                     
                     Note that an inactive connection still can be 

--- a/2.0/sphinx/web-admin/outgoing/sql.txt
+++ b/2.0/sphinx/web-admin/outgoing/sql.txt
@@ -25,7 +25,7 @@ Name                Connection name
 Active              Whether the connection can be used by services or not. 
 
                     If a connection is not active a service will encounter a 
-                    `zato.common.Inactive <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/__init__.py>`_
+                    `zato.common.Inactive <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/__init__.py>`_
                     exception when attempting to use it.
                     
                     Note that an inactive connection still can be 
@@ -49,7 +49,7 @@ Ping
 .. image:: /gfx/web-admin/outgoing/sql-ping.png
 
 A connection can be pinged - this sends 
-`a dummy query <https://github.com/zatosource/zato/blob/master/code/zato-common/src/zato/common/odb/__init__.py>`_
+`a dummy query <https://github.com/zatosource/zato/blob/main/code/zato-common/src/zato/common/odb/__init__.py>`_
 from one of a  cluster's servers. This can be used to check whether a given
 database is reachable by Zato servers.
 


### PR DESCRIPTION
All the links were pointing to the `master` branch, which does not actually exist in the repo. This commit changes the links to make them point to the `main` branch, which does currently exist in the repo.