### PR TITLE
Renamed get_name to get_name_static for 3.0

### DIFF
--- a/3.0/sphinx/progguide/hooks/service.txt
+++ b/3.0/sphinx/progguide/hooks/service.txt
@@ -66,14 +66,14 @@ Method                                                                   Notes
 
         @staticmethod
         def before_add_to_store(logger):
-            logger.info('Adding to store {}'.format(MyService.get_name()))
+            logger.info('Adding to store {}'.format(MyService.get_name_static()))
 
             # Don't forget to return True, otherwise the service won't be deployed
             return True
 
         @staticmethod
         def after_add_to_store(logger):
-            logger.info('Added to store {}'.format(MyService.get_name()))
+            logger.info('Added to store {}'.format(MyService.get_name_static()))
 
         def before_handle(self):
             self.logger.info('before_handle called')

--- a/3.0/sphinx/progguide/service-dev.txt
+++ b/3.0/sphinx/progguide/service-dev.txt
@@ -488,7 +488,7 @@ name
 Name of the service under which it will be possible to :ref:`invoke it <progguide-write-service-invoke>` and point to it
 in the web admin. Contrast with :ref:`impl_name <progguide-write-service-impl_name>`.
 
-Visit :ref:`get_name <progguide-write-service-get_name>` for a way to override it.
+Visit :ref:`get_name_static <progguide-write-service-get_name_static>` for a way to override it.
 
 ::
 
@@ -900,12 +900,12 @@ finalize_handle
 Method executed after :ref:`handle <progguide-write-service-handle>` and other service
 hooks have completed. Explained further in the :doc:`chapter on service hooks <./hooks/service>`.
 
-.. _progguide-write-service-get_name:
+.. _progguide-write-service-get_name_static:
 
-get_name
+get_name_static
 ````````
 
-.. py:staticmethod:: get_name()
+.. py:staticmethod:: get_name_static()
 
 A static method that should be implemented to return
 :ref:`service names <progguide-write-service-name>` other than what Zato
@@ -920,7 +920,7 @@ automatically generates.
           self.logger.info('My name is {}'.format(self.name))
 
       @staticmethod
-      def get_name():
+      def get_name_static():
           return 'Something Else'
 
 ::

--- a/3.0/sphinx/tutorial/01.txt
+++ b/3.0/sphinx/tutorial/01.txt
@@ -432,7 +432,7 @@ still not possible to access it from the outside.
 A question may arise, how come the service is called my-service.get-client-details?
 It's because Zato uncamelifies strings such as MyFancyName or PrepareCustomerDocuments
 into my-fancy-name or prepare-customer-documents to make them more Pythonic.
-Naturally, this can be :ref:`overridden <progguide-write-service-get_name>`.
+Naturally, this can be :ref:`overridden <progguide-write-service-get_name_static>`.
 
 Exposing a service over HTTP and invoking it
 --------------------------------------------


### PR DESCRIPTION
With 3.0 static method get_name was renamed to get_name_static.
This pull request renames this method in docs.